### PR TITLE
retrying message should appear before waiting for 60 seconds

### DIFF
--- a/push_physical_badging_records.ps1
+++ b/push_physical_badging_records.ps1
@@ -76,10 +76,10 @@ function RetryCommand {
             }
             catch {
                 Write-Error $_.Exception.InnerException.Message -ErrorAction Continue
-                Start-Sleep 60
                 if ($cnt -lt $Maximum) {
                     Write-Host "Retrying"
                 }
+                Start-Sleep 60
             }
             
         } while ($cnt -lt $Maximum)


### PR DESCRIPTION
Customer doesn't wait for 60 seconds if the retrying command is not prompted. Modified the code accordingly.