### PR TITLE
Will retry message to appear before 60 seconds wait time

### DIFF
--- a/push_physical_badging_records.ps1
+++ b/push_physical_badging_records.ps1
@@ -12,6 +12,8 @@ param
     [string] $jobId,
     [Parameter(mandatory = $true)]
     [string] $jsonFilePath
+    [Parameter(mandatory = $false)]
+    [Int] $retryTimeout
 )
 
 # Access Token Config
@@ -76,10 +78,11 @@ function RetryCommand {
             }
             catch {
                 Write-Error $_.Exception.InnerException.Message -ErrorAction Continue
+                Write-Host ("Will retry in [{0}] seconds" -f $retryTimeout)
+                Start-Sleep $retryTimeout
                 if ($cnt -lt $Maximum) {
                     Write-Host "Retrying"
                 }
-                Start-Sleep 60
             }
             
         } while ($cnt -lt $Maximum)

--- a/push_physical_badging_records.ps1
+++ b/push_physical_badging_records.ps1
@@ -11,7 +11,7 @@ param
     [Parameter(mandatory = $true)]
     [string] $jobId,
     [Parameter(mandatory = $true)]
-    [string] $jsonFilePath
+    [string] $jsonFilePath,
     [Parameter(mandatory = $false)]
     [Int] $retryTimeout
 )

--- a/push_physical_badging_records.ps1
+++ b/push_physical_badging_records.ps1
@@ -76,10 +76,10 @@ function RetryCommand {
             }
             catch {
                 Write-Error $_.Exception.InnerException.Message -ErrorAction Continue
-                Start-Sleep 60
                 if ($cnt -lt $Maximum) {
                     Write-Host "Retrying"
                 }
+                Start-Sleep 60
             }
             
         } while ($cnt -lt $Maximum)

--- a/push_physical_badging_records_ITARL4.ps1
+++ b/push_physical_badging_records_ITARL4.ps1
@@ -12,6 +12,8 @@ param
     [string] $jobId,
     [Parameter(mandatory = $true)]
     [string] $jsonFilePath
+    [Parameter(mandatory = $false)]
+    [Int] $retryTimeout = 60
 )
 
 # Access Token Config
@@ -76,7 +78,8 @@ function RetryCommand {
             }
             catch {
                 Write-Error $_.Exception.InnerException.Message -ErrorAction Continue
-                Start-Sleep 60
+                Write-Host ("Will retry in [{0}] seconds" -f $retryTimeout)
+                Start-Sleep $retryTimeout
                 if ($cnt -lt $Maximum) {
                     Write-Host "Retrying"
                 }

--- a/push_physical_badging_records_ITARL4.ps1
+++ b/push_physical_badging_records_ITARL4.ps1
@@ -11,7 +11,7 @@ param
     [Parameter(mandatory = $true)]
     [string] $jobId,
     [Parameter(mandatory = $true)]
-    [string] $jsonFilePath
+    [string] $jsonFilePath,
     [Parameter(mandatory = $false)]
     [Int] $retryTimeout = 60
 )

--- a/push_physical_badging_records_ITARL5.ps1
+++ b/push_physical_badging_records_ITARL5.ps1
@@ -12,6 +12,8 @@ param
     [string] $jobId,
     [Parameter(mandatory = $true)]
     [string] $jsonFilePath
+    [Parameter(mandatory = $false)]
+    [Int] $retryTimeout
 )
 
 # Access Token Config
@@ -76,7 +78,8 @@ function RetryCommand {
             }
             catch {
                 Write-Error $_.Exception.InnerException.Message -ErrorAction Continue
-                Start-Sleep 60
+                Write-Host ("Will retry in [{0}] seconds" -f $retryTimeout)
+                Start-Sleep $retryTimeout
                 if ($cnt -lt $Maximum) {
                     Write-Host "Retrying"
                 }

--- a/push_physical_badging_records_ITARL5.ps1
+++ b/push_physical_badging_records_ITARL5.ps1
@@ -11,7 +11,7 @@ param
     [Parameter(mandatory = $true)]
     [string] $jobId,
     [Parameter(mandatory = $true)]
-    [string] $jsonFilePath
+    [string] $jsonFilePath,
     [Parameter(mandatory = $false)]
     [Int] $retryTimeout
 )

--- a/push_physical_badging_records_gcc.ps1
+++ b/push_physical_badging_records_gcc.ps1
@@ -12,6 +12,8 @@ param
     [string] $jobId,
     [Parameter(mandatory = $true)]
     [string] $jsonFilePath
+    [Parameter(mandatory = $false)]
+    [Int] $retryTimeout
 )
 
 # Access Token Config
@@ -76,7 +78,8 @@ function RetryCommand {
             }
             catch {
                 Write-Error $_.Exception.InnerException.Message -ErrorAction Continue
-                Start-Sleep 60
+                Write-Host ("Will retry in [{0}] seconds" -f $retryTimeout)
+                Start-Sleep $retryTimeout
                 if ($cnt -lt $Maximum) {
                     Write-Host "Retrying"
                 }

--- a/push_physical_badging_records_gcc.ps1
+++ b/push_physical_badging_records_gcc.ps1
@@ -11,7 +11,7 @@ param
     [Parameter(mandatory = $true)]
     [string] $jobId,
     [Parameter(mandatory = $true)]
-    [string] $jsonFilePath
+    [string] $jsonFilePath,
     [Parameter(mandatory = $false)]
     [Int] $retryTimeout
 )


### PR DESCRIPTION
Customer doesn't wait for 60 seconds for retrying to happen if not prompted with a retry message. These code changes are implemented so that a message appears before retry actually happens. 