### PR TITLE
Retry was not happening on failure

### DIFF
--- a/push_physical_badging_records.ps1
+++ b/push_physical_badging_records.ps1
@@ -62,7 +62,7 @@ function RetryCommand {
         [scriptblock]$ScriptBlock,
 
         [Parameter(Position = 1, Mandatory = $false)]
-        [int]$Maximum = 15
+        [int]$Maximum = 5
     )
 
     Begin {
@@ -150,7 +150,9 @@ function PushPhysicalBadgingRecords ($access_token) {
             throw "Service unavailable."
         }
         else {
-            WriteErrorMessage("Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase)
+            $errorstring = "Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase
+            WriteErrorMessage($errorstring)
+	        throw $errorstring
         }
     }
 }

--- a/push_physical_badging_records.ps1
+++ b/push_physical_badging_records.ps1
@@ -152,7 +152,7 @@ function PushPhysicalBadgingRecords ($access_token) {
         else {
             $errorstring = "Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase
             WriteErrorMessage($errorstring)
-	        throw $errorstring
+	    throw $errorstring
         }
     }
 }

--- a/push_physical_badging_records_ITARL4.ps1
+++ b/push_physical_badging_records_ITARL4.ps1
@@ -62,7 +62,7 @@ function RetryCommand {
         [scriptblock]$ScriptBlock,
 
         [Parameter(Position = 1, Mandatory = $false)]
-        [int]$Maximum = 15
+        [int]$Maximum = 5
     )
 
     Begin {
@@ -150,7 +150,9 @@ function PushPhysicalBadgingRecords ($access_token) {
             throw "Service unavailable."
         }
         else {
-            WriteErrorMessage("Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase)
+            $errorstring = "Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase
+            WriteErrorMessage($errorstring)
+	        throw $errorstring
         }
     }
 }

--- a/push_physical_badging_records_ITARL4.ps1
+++ b/push_physical_badging_records_ITARL4.ps1
@@ -152,7 +152,7 @@ function PushPhysicalBadgingRecords ($access_token) {
         else {
             $errorstring = "Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase
             WriteErrorMessage($errorstring)
-	        throw $errorstring
+            throw $errorstring
         }
     }
 }

--- a/push_physical_badging_records_ITARL5.ps1
+++ b/push_physical_badging_records_ITARL5.ps1
@@ -62,7 +62,7 @@ function RetryCommand {
         [scriptblock]$ScriptBlock,
 
         [Parameter(Position = 1, Mandatory = $false)]
-        [int]$Maximum = 15
+        [int]$Maximum = 5
     )
 
     Begin {
@@ -150,7 +150,9 @@ function PushPhysicalBadgingRecords ($access_token) {
             throw "Service unavailable."
         }
         else {
-            WriteErrorMessage("Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase)
+            $errorstring = "Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase
+            WriteErrorMessage($errorstring)
+	        throw $errorstring
         }
     }
 }

--- a/push_physical_badging_records_ITARL5.ps1
+++ b/push_physical_badging_records_ITARL5.ps1
@@ -152,7 +152,7 @@ function PushPhysicalBadgingRecords ($access_token) {
         else {
             $errorstring = "Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase
             WriteErrorMessage($errorstring)
-	        throw $errorstring
+	    throw $errorstring
         }
     }
 }

--- a/push_physical_badging_records_gcc.ps1
+++ b/push_physical_badging_records_gcc.ps1
@@ -62,7 +62,7 @@ function RetryCommand {
         [scriptblock]$ScriptBlock,
 
         [Parameter(Position = 1, Mandatory = $false)]
-        [int]$Maximum = 15
+        [int]$Maximum = 5
     )
 
     Begin {
@@ -150,7 +150,9 @@ function PushPhysicalBadgingRecords ($access_token) {
             throw "Service unavailable."
         }
         else {
-            WriteErrorMessage("Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase)
+            $errorstring = "Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase
+            WriteErrorMessage($errorstring)
+	        throw $errorstring
         }
     }
 }

--- a/push_physical_badging_records_gcc.ps1
+++ b/push_physical_badging_records_gcc.ps1
@@ -152,7 +152,7 @@ function PushPhysicalBadgingRecords ($access_token) {
         else {
             $errorstring = "Failure with StatusCode [{0}] and ReasonPhrase [{1}]" -f $result.StatusCode, $result.ReasonPhrase
             WriteErrorMessage($errorstring)
-	        throw $errorstring
+	    throw $errorstring
         }
     }
 }


### PR DESCRIPTION
Retry was not getting triggerred because the failure block was not throwing an error and simply printing a message, changed to throw an error and verified by testing locally.
Also the retry count was 15 before, changed it to 5
![image](https://github.com/microsoft/m365-physical-badging-connector-sample-scripts/assets/112610093/082555c9-607f-4608-86bc-aa24e00f4bee)
