### PR TITLE
Resolve Security Warning: Add -UseBasicParsing to Physical Badging

### DIFF
--- a/push_physical_badging_records.ps1
+++ b/push_physical_badging_records.ps1
@@ -134,7 +134,7 @@ function PushPhysicalBadgingRecords ($access_token) {
         Write-Host -fore yellow "Processing chunk $chunkCount of $($Chunks.Count) with $($chnk.Length) records"
         $jsonChunk = $chnk | ConvertTo-Json
         try {
-            $result = Invoke-WebRequest -Uri $url -Method POST -Body $jsonChunk -Headers $headers -TimeoutSec 400
+            $result = Invoke-WebRequest -Uri $url -Method POST -Body $jsonChunk -Headers $headers -TimeoutSec 400 -UseBasicParsing
         }
         catch {
             WriteErrorMessage($_)

--- a/push_physical_badging_records_ITARL4.ps1
+++ b/push_physical_badging_records_ITARL4.ps1
@@ -134,7 +134,7 @@ function PushPhysicalBadgingRecords ($access_token) {
         Write-Host -fore yellow "Processing chunk $chunkCount of $($Chunks.Count) with $($chnk.Length) records"
         $jsonChunk = $chnk | ConvertTo-Json
         try {
-            $result = Invoke-WebRequest -Uri $url -Method POST -Body $jsonChunk -Headers $headers -TimeoutSec 400
+            $result = Invoke-WebRequest -Uri $url -Method POST -Body $jsonChunk -Headers $headers -TimeoutSec 400 -UseBasicParsing
         }
         catch {
             WriteErrorMessage($_)

--- a/push_physical_badging_records_ITARL5.ps1
+++ b/push_physical_badging_records_ITARL5.ps1
@@ -134,7 +134,7 @@ function PushPhysicalBadgingRecords ($access_token) {
         Write-Host -fore yellow "Processing chunk $chunkCount of $($Chunks.Count) with $($chnk.Length) records"
         $jsonChunk = $chnk | ConvertTo-Json
         try {
-            $result = Invoke-WebRequest -Uri $url -Method POST -Body $jsonChunk -Headers $headers -TimeoutSec 400
+            $result = Invoke-WebRequest -Uri $url -Method POST -Body $jsonChunk -Headers $headers -TimeoutSec 400 -UseBasicParsing
         }
         catch {
             WriteErrorMessage($_)

--- a/push_physical_badging_records_gcc.ps1
+++ b/push_physical_badging_records_gcc.ps1
@@ -134,7 +134,7 @@ function PushPhysicalBadgingRecords ($access_token) {
         Write-Host -fore yellow "Processing chunk $chunkCount of $($Chunks.Count) with $($chnk.Length) records"
         $jsonChunk = $chnk | ConvertTo-Json
         try {
-            $result = Invoke-WebRequest -Uri $url -Method POST -Body $jsonChunk -Headers $headers -TimeoutSec 400
+            $result = Invoke-WebRequest -Uri $url -Method POST -Body $jsonChunk -Headers $headers -TimeoutSec 400 -UseBasicParsing
         }
         catch {
             WriteErrorMessage($_)


### PR DESCRIPTION
Resolve Security Warning: Add -UseBasicParsing to Physical badging script